### PR TITLE
Split on any number of blank spaces

### DIFF
--- a/Taylor-Tests/Taylor_Tests.swift
+++ b/Taylor-Tests/Taylor_Tests.swift
@@ -51,6 +51,17 @@ class Taylor_Tests: XCTestCase {
         XCTAssertEqual(request.headers.count, 3, "Header parsing")
         XCTAssertEqual(request.arguments["name"]!, "jorge", "Arg parsing")
     }
+
+    func testRequestParsingWithMultipleSP() {
+
+        let string = "GET   /write?space=name  HTTP/1.1\r\nHost: localhost:1989\r\nHeader2: It's gonna go down in flames\r\n\r\ndaydream"
+        let request = TRequest(data: string.dataUsingEncoding(NSUTF8StringEncoding))
+
+        XCTAssertEqual(request.method, Taylor.HTTPMethod.GET, "Method parsing")
+        XCTAssertEqual(request.path, "/write", "Path parsing")
+        XCTAssertEqual(request.headers.count, 2, "Header parsing")
+        XCTAssertEqual(request.arguments["space"]!, "name", "Arg parsing")
+    }
     
     func testBodyParsing() {
         

--- a/taylor/request.swift
+++ b/taylor/request.swift
@@ -61,8 +61,9 @@ public class TRequest: TRequestProtocol {
         
         //Parse method
         if http.count > 0 {
-            
-            var startLineArr: [String] = http[0].componentsSeparatedByString(" ") //One space
+
+            // The delimiter can be any number of blank spaces
+            var startLineArr: [String] = split(http[0], { $0 == " "}, maxSplit: Int.max, allowEmptySlices: false)
             
             if startLineArr.count > 0 {
                 


### PR DESCRIPTION
In older versions of HTTP/1.1, any number of linear white space can be used as a delimiter in HTTP header values. While still far from robust, it's a starter.

https://www.ietf.org/rfc/rfc2616.txt
http://stackoverflow.com/questions/17463676/are-multiple-linear-white-space-allowed-in-http-header
