### PR TITLE
Refactor and improve Middleware.staticDirectory

### DIFF
--- a/taylor/Taylor.xcodeproj/project.pbxproj
+++ b/taylor/Taylor.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		6E267E341AD069EF0077B974 /* stdext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E267E331AD069EF0077B974 /* stdext.swift */; };
 		E1D6FAC11AB5E91700399154 /* Taylor.h in Headers */ = {isa = PBXBuildFile; fileRef = E1D6FAC01AB5E91700399154 /* Taylor.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		E1D6FAC71AB5E91700399154 /* Taylor.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E1D6FABB1AB5E91700399154 /* Taylor.framework */; };
 		E1D6FAE11AB5E95900399154 /* FileTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1D6FAD81AB5E95900399154 /* FileTypes.swift */; };
@@ -34,6 +35,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		6E267E331AD069EF0077B974 /* stdext.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = stdext.swift; path = ../../taylor/Taylor/stdext.swift; sourceTree = "<group>"; };
 		E1D6FABB1AB5E91700399154 /* Taylor.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Taylor.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		E1D6FABF1AB5E91700399154 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		E1D6FAC01AB5E91700399154 /* Taylor.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Taylor.h; sourceTree = "<group>"; };
@@ -105,6 +107,7 @@
 				E1D6FAD81AB5E95900399154 /* FileTypes.swift */,
 				E1D6FAEB1AB5E98D00399154 /* dependencies */,
 				E1D6FABE1AB5E91700399154 /* Supporting Files */,
+				6E267E331AD069EF0077B974 /* stdext.swift */,
 			);
 			path = Taylor;
 			sourceTree = "<group>";
@@ -257,6 +260,7 @@
 				E1D6FAE81AB5E95900399154 /* Taylor.swift in Sources */,
 				E1D6FAE11AB5E95900399154 /* FileTypes.swift in Sources */,
 				E1D6FAE61AB5E95900399154 /* Router.swift in Sources */,
+				6E267E341AD069EF0077B974 /* stdext.swift in Sources */,
 				E1D6FAE51AB5E95900399154 /* Route.swift in Sources */,
 				E1D6FAF01AB5E98D00399154 /* GCDAsyncSocket.m in Sources */,
 				E1D6FAE21AB5E95900399154 /* Middleware.swift in Sources */,

--- a/taylor/Taylor/middleware.swift
+++ b/taylor/Taylor/middleware.swift
@@ -67,9 +67,7 @@ public class Middleware {
             }
             
             let fileComponents = requestComponents[dirComponents.count..<requestComponents.count] // matched comps after dirComponents
-            println(fileComponents)
             var filePath = directory.stringByExpandingTildeInPath.stringByAppendingPathComponent(join("/", fileComponents))
-            println(filePath)
             
             let fileManager = NSFileManager.defaultManager()
             var isDir: ObjCBool = false

--- a/taylor/Taylor/stdext.swift
+++ b/taylor/Taylor/stdext.swift
@@ -1,0 +1,10 @@
+import Foundation
+
+extension String {
+    /// Components of a path; ignores the leading slash and empty components
+    /// e.g. "/foo/bar/baz" -> [foo, bar, baz]
+    
+    var taylor_pathComponents: [String] {
+        return self.componentsSeparatedByString("/").filter { $0 != "" }
+    }
+}


### PR DESCRIPTION
- Refactor Middleware.staticDirectory
  - 80 LOC → 30 LOC
  - Avoid explicit imperative loops
  - Helper method `String.taylor_pathComponents` to replace previous loops
  - Helper method `Middleware.matchPaths` to compare path component arrays
- Define `staticDirectory(bundle:)` in terms of `staticDirectory(directory:)`
  - Avoids ambiguity (can't pass both or none)
  - Removes unnecessary code
  - Automatic `foo/` → `foo/index.html` matching now works with bundle variant
