### PR TITLE
Share schemes for CI and other people

### DIFF
--- a/taylor/Taylor.xcodeproj/xcshareddata/xcschemes/Taylor.xcscheme
+++ b/taylor/Taylor.xcodeproj/xcshareddata/xcschemes/Taylor.xcscheme
@@ -1,0 +1,99 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0700"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "E1D6FABA1AB5E91700399154"
+               BuildableName = "Taylor.framework"
+               BlueprintName = "Taylor"
+               ReferencedContainer = "container:Taylor.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "E1D6FAC51AB5E91700399154"
+               BuildableName = "TaylorTests.xctest"
+               BlueprintName = "TaylorTests"
+               ReferencedContainer = "container:Taylor.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "E1D6FABA1AB5E91700399154"
+            BuildableName = "Taylor.framework"
+            BlueprintName = "Taylor"
+            ReferencedContainer = "container:Taylor.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "E1D6FABA1AB5E91700399154"
+            BuildableName = "Taylor.framework"
+            BlueprintName = "Taylor"
+            ReferencedContainer = "container:Taylor.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "E1D6FABA1AB5E91700399154"
+            BuildableName = "Taylor.framework"
+            BlueprintName = "Taylor"
+            ReferencedContainer = "container:Taylor.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>


### PR DESCRIPTION
Xcode schemes must be shared for other people to be able to build it. I had error from Carthage saying 

```
Project "Taylor.xcodeproj" has no shared schemes
```

UPD:
This also fixes issue with CocoaPods (Rome), specifically error like this:

```
[!] The platform of the target `Pods` (OS X 10.9) is not compatible with `Taylor (HEAD based on 0.1.0)`, which does not support `osx`.
```
