### PR TITLE
Make Taylor Xcode 7 Beta 5 Compatible

### DIFF
--- a/Playground.playground/Sources/SupportCode.swift
+++ b/Playground.playground/Sources/SupportCode.swift
@@ -12,7 +12,7 @@ public func filteredImage(filterName: String) -> NSData? {
     let image = CIImage(contentsOfURL: imageURL!)
     let filter = CIFilter(name: filterName)
     filter!.setValue(image, forKey: kCIInputImageKey)
-    let imageRep = NSBitmapImageRep(CIImage: filter!.outputImage)
+    let imageRep = NSBitmapImageRep(CIImage: filter!.outputImage!)
     return imageRep.representationUsingType(.NSJPEGFileType, properties: [NSImageCompressionFactor:0.3])
 }
 public func getIPAddress() -> String {

--- a/taylor/Taylor/middleware.swift
+++ b/taylor/Taylor/middleware.swift
@@ -38,8 +38,8 @@ public class Middleware {
                                 val = arg[1]
                             }
                             
-                            let key = arg[0].stringByReplacingPercentEscapesUsingEncoding(NSASCIIStringEncoding)!.stringByReplacingOccurrencesOfString("+", withString: " ", options: .LiteralSearch, range: nil) as String
-                            let value = val.stringByReplacingPercentEscapesUsingEncoding(NSASCIIStringEncoding)!.stringByReplacingOccurrencesOfString("+", withString: " ", options: .LiteralSearch, range: nil) as String
+                            let key = arg[0].NS.stringByReplacingPercentEscapesUsingEncoding(NSASCIIStringEncoding)!.stringByReplacingOccurrencesOfString("+", withString: " ", options: .LiteralSearch, range: nil) as String
+                            let value = val.NS.stringByReplacingPercentEscapesUsingEncoding(NSASCIIStringEncoding)!.stringByReplacingOccurrencesOfString("+", withString: " ", options: .LiteralSearch, range: nil) as String
                             
                             request.body[key] = value.stringByReplacingOccurrencesOfString("\n", withString: "", options: .LiteralSearch, range: nil)
                         }
@@ -67,15 +67,15 @@ public class Middleware {
             }
             
             let fileComponents = requestComponents[dirComponents.count..<requestComponents.count] // matched comps after dirComponents
-            var filePath = directory.stringByExpandingTildeInPath.stringByAppendingPathComponent("/".join(fileComponents))
+            var filePath = directory.NS.stringByExpandingTildeInPath.NS.stringByAppendingPathComponent("/".join(fileComponents))
             
             let fileManager = NSFileManager.defaultManager()
             var isDir: ObjCBool = false
             
             if fileManager.fileExistsAtPath(filePath, isDirectory: &isDir){
                 // In case it is a directory, we look for a index.html file inside
-                if Bool(isDir) && fileManager.fileExistsAtPath(filePath.stringByAppendingPathComponent("index.html")) {
-                    filePath = filePath.stringByAppendingPathComponent("index.html")
+                if Bool(isDir) && fileManager.fileExistsAtPath(filePath.NS.stringByAppendingPathComponent("index.html")) {
+                    filePath = filePath.NS.stringByAppendingPathComponent("index.html")
                 }
                 
                 response.setFile(NSURL(fileURLWithPath: filePath))

--- a/taylor/Taylor/request.swift
+++ b/taylor/Taylor/request.swift
@@ -63,7 +63,7 @@ public class Request {
         if http.count > 0 {
 
             // The delimiter can be any number of blank spaces
-            var startLineArr: [String] = split(http[0].characters, maxSplit: Int.max, allowEmptySlices: false) { $0 == " "}.map { String($0) }
+            var startLineArr: [String] = http[0].characters.split { $0 == " " }.map { String($0) }//split(http[0].characters, maxSplit: Int.max, allowEmptySlices: false) { $0 == " "}.map { String($0) }
             
             if startLineArr.count > 0 {
                 

--- a/taylor/Taylor/stdext.swift
+++ b/taylor/Taylor/stdext.swift
@@ -7,4 +7,8 @@ extension String {
     var taylor_pathComponents: [String] {
         return self.componentsSeparatedByString("/").filter { $0 != "" }
     }
+    
+    var NS: NSString {
+        return self as NSString
+    }
 }


### PR DESCRIPTION
In the latest version of Xcode beta, Apple removed some methods from the Swift String type. An easy workaround (which I applied) is to cast String to NSString whenever it is necessary to use those methods. More info about these changes are available in [this](https://forums.developer.apple.com/message/37935) forum thread.
