### PR TITLE
Update podspec to include CocoaAsyncSocket source files

### DIFF
--- a/Taylor.podspec
+++ b/Taylor.podspec
@@ -11,7 +11,7 @@ Pod::Spec.new do |s|
   s.ios.deployment_target = '8.0'
   s.osx.deployment_target = '10.9'
 
-  s.source_files = 'taylor/Taylor/*.swift'
+  s.source_files = 'taylor/Taylor/*.swift', 'taylor/Taylor/dependencies/*.{h,m}'
 
   s.requires_arc = true
 


### PR DESCRIPTION
Currently, if one were to add the following line to their podfile: `pod 'Taylor', :git => 'https://github.com/izqui/Taylor.git'` followed by a `pod install`, Taylor wouldn't build because it relies on CocoaAsyncSocket but doesn't include the source files. This pull request contains one commit which adds the CocoaAsyncSocket directory search path to the podspec.
