### PR TITLE
Fix issue where Request body was sometimes incorrectly empty

### DIFF
--- a/Taylor/Request.swift
+++ b/Taylor/Request.swift
@@ -117,6 +117,19 @@ public class Request {
                 self.headers.updateValue(header[1], forKey: header[0])
             }
         }
+        
+        if i < http.count && (self.method == Taylor.HTTPMethod.POST || false) { // Add other methods that support body data
+            
+            var str = ""
+            while ++i < http.count {
+                
+                if !http[i].isEmpty {
+                    str += "\(http[i])\n"
+                }
+            }
+            
+            self.bodyString = str.isEmpty ? nil : str
+        }
     }
     
     func parseBodyData(d: NSData?){

--- a/Taylor/Request.swift
+++ b/Taylor/Request.swift
@@ -38,22 +38,15 @@ public class Request {
     internal var startTime = NSDate()
     var _protocol: String?
     
-    convenience init(){
-        
-        self.init(data: nil)
-    }
 
-    init(data d: NSData?){
+
+    init(headerData: NSData){
         
         self.path = String()
-        //Parsing data from socket to build a HTTP request
-        if d != nil {
-            
-            self.parseRequest(d!)
-        }
+        self.parseHeaderData(headerData)
     }
     
-    private func parseRequest(d: NSData){
+    private func parseHeaderData(d: NSData){
         
         //TODO: Parse data line by line, so if body content is not UTF8 encoded, this doesn't crash
         let string = String(data: d, encoding: NSUTF8StringEncoding)
@@ -124,16 +117,11 @@ public class Request {
                 self.headers.updateValue(header[1], forKey: header[0])
             }
         }
-        
-        if i < http.count && (self.method == Taylor.HTTPMethod.POST || false) { // Add other methods that support body data
-            
-            var str = String()
-            while ++i < http.count {
-                
-                str += "\(http[i])\n"
-            }
-            
-            self.bodyString = str
+    }
+    
+    func parseBodyData(d: NSData?){
+        if let data = d {
+            bodyString = String(data: data, encoding: NSUTF8StringEncoding)
         }
     }
 }

--- a/Taylor/Taylor.swift
+++ b/Taylor/Taylor.swift
@@ -57,9 +57,9 @@ public class Server {
     
     public func serveHTTP(port p: Int, forever: Bool) throws {
         
-        socket.receivedDataCallback = {
-            data, socket in
-            self.handleRequest(socket, request: Request(data: data), response: Response())
+        socket.receivedRequestCallback = {
+            request, socket in
+            self.handleRequest(socket, request: request, response: Response())
             return true
         }
         try socket.startOnPort(p)


### PR DESCRIPTION
Fixes issue discussed in #2 

In order to handle this case when using `GCDAsyncSocket`, I needed to split the initialization process for requests into two parts, which meant the `receivedDataCallback` also needed to change. This feels like a better approach anyway, as the request headers need to be parsed first in order to determine the formatting and size of the request body (especially to handle more complex situations).
