### PR TITLE
Fix issues #12 & #11

### DIFF
--- a/Taylor/HandlerExecutor.swift
+++ b/Taylor/HandlerExecutor.swift
@@ -33,7 +33,7 @@ class HandlerExecutor {
                     guard let result = onContinueWithNoHandlersLeft?(request, response) else {
                         // usually means that no actual response
                         // is being sent (ex: hooks)
-                        return .Continue(request, response)
+                        return .Send(request, response)
                     }
                     
                     // usually a .Send with a 404 page or something


### PR DESCRIPTION
In my testing, it still returns a 404 on an incorrect path, but if the last handler is a `.Continue`, then it doesn't (which seems to be a good thing).

It also fixes #12 since we can just have all middleware return `.Continue` and still get the expected results.
